### PR TITLE
Add 'Show Version' option to widget

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -170,7 +170,7 @@ class EDD_Download_Info_Widget extends WP_Widget {
 		<?php }
 
 		/* If version is set, echo it. */
-		if ( !empty( $version ) ) { ?>
+		if ($instance['show_version'] && !empty( $version ) ) { ?>
 
 			<li><?php printf( __( '<span class="edd-download-info-version">Version:</span> %1$s', 'edd-download-info' ), $version ); ?></li>
 
@@ -224,6 +224,7 @@ class EDD_Download_Info_Widget extends WP_Widget {
 		$instance['show_demo_link'] = strip_tags( $new_instance['show_demo_link'] );
 		$instance['open_demo_link'] = strip_tags( $new_instance['open_demo_link'] );
 		$instance['show_download_count'] = strip_tags( $new_instance['show_download_count'] );
+                $instance['show_version'] = strip_tags( $new_instance['show_version'] );
 
 		return $instance;
 
@@ -243,7 +244,8 @@ class EDD_Download_Info_Widget extends WP_Widget {
 			'show_purchase_link' => 1,
 			'show_demo_link' => 1,
 			'open_demo_link' => 1,
-			'show_download_count' => 1
+			'show_download_count' => 1,
+                        'show_version' => true
 		) );
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -279,6 +281,10 @@ class EDD_Download_Info_Widget extends WP_Widget {
 				<input type="checkbox" value="1" <?php checked( '1', $instance['show_download_count'] ); ?> id="<?php echo $this->get_field_id( 'show_download_count' ); ?>" name="<?php echo $this->get_field_name( 'show_download_count' ); ?>" />
 				<label for="<?php echo $this->get_field_id( 'show_download_count' ); ?>"><?php _e( 'Show download count?', 'edd-download-info' ); ?></label>
 			</p>
+			<p>
+				<input type="checkbox" value="1" <?php checked( '1', $instance['show_version'] ); ?> id="<?php echo $this->get_field_id( 'show_version' ); ?>" name="<?php echo $this->get_field_name( 'show_version' ); ?>" />
+				<label for="<?php echo $this->get_field_id( 'show_version' ); ?>"><?php _e( 'Show version?', 'edd-download-info' ); ?></label>
+			</p>                        
 
 		<div style="clear:both;">&nbsp;</div>
 	<?php

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === EDD Download Info ===
-Contributors: sami.keijonen
+Contributors: sami.keijonen, kprovance
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=E65RCFVD3QGYU
 Tags: EDD, download, downloads, add-on, digital, easy 
 Requires at least: 3.9


### PR DESCRIPTION
Here is my logic on this proposed change:

In writing EDD compatibility with my theme, I am adding styling for this plugin, plus the software licensing plugin, both of which offer version information.  However, there is no reliable way to hide that information on the widget output.  There is no CSS solution as the version output is inside a li tag with no class or id, with the actual version number outside of the span.  There is just no way to hide it.  Using nth-child is also not very reliable.  I see two ways to overcome that:  Add the option, or add a class to that li tag.  I opted for the former.  It's nice to have that version info for some theme proprietary code, without having the actual widget output, and no css way to hide it.